### PR TITLE
fix: allow iframe embedding from any origin

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -29,6 +29,29 @@ HOST=0.0.0.0 PORT=4190 npm start
 
 The health check endpoint is `GET /healthz`.
 
+## Embed In An Iframe
+
+The server allows iframe embedding from any parent origin, including local
+development pages. It omits CSP `frame-ancestors` and `X-Frame-Options` while
+preserving the other security headers. Reverse proxies must not add restrictive
+`frame-ancestors` or `X-Frame-Options` headers if embedding should remain available.
+
+```html
+<iframe
+  src="https://folotoy-passport-simulator.onrender.com/?play=100"
+  title="AI Passport 在线试玩"
+  allow="microphone; autoplay; fullscreen"
+></iframe>
+```
+
+The embedding page's own CSP must also permit the simulator in `frame-src`.
+Sound still requires a user click, and microphone access requires browser
+permission in a secure context. To test before deploying community changes,
+temporarily insert the iframe in a community page using browser DevTools, or
+use a local preview page. This changes only the test browser's DOM; refreshing
+restores the original page. The deployed simulator must include this header
+change before remote embedding can work.
+
 ## Environment Variables
 
 | Variable | Default | Production recommendation | Description |

--- a/server.mjs
+++ b/server.mjs
@@ -30,14 +30,13 @@ const securityHeaders = {
   "content-security-policy":
     "default-src 'self'; base-uri 'none'; connect-src 'self'; img-src 'self' data:; " +
     "media-src 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; " +
-    "worker-src 'self'; frame-ancestors 'none'",
+    "worker-src 'self'",
   "cross-origin-embedder-policy": "require-corp",
   "cross-origin-opener-policy": "same-origin",
   "cross-origin-resource-policy": "same-origin",
   "permissions-policy": "camera=(), geolocation=(), serial=()",
   "referrer-policy": "no-referrer",
   "x-content-type-options": "nosniff",
-  "x-frame-options": "DENY",
 };
 
 function assetPath(pathname) {

--- a/test/embedding-policy.test.mjs
+++ b/test/embedding-policy.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import test from "node:test";
+
+import { createAppServer } from "../server.mjs";
+
+test("HTML does not restrict iframe parent origins", async (t) => {
+  const server = createAppServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+
+  for (const pathname of ["/", "/?play=100", "/index.html?play=100"]) {
+    for (const method of ["GET", "HEAD"]) {
+      const response = await fetch(`${origin}${pathname}`, { method });
+      assert.equal(response.status, 200);
+      const policy = response.headers.get("content-security-policy");
+      const ancestors = policy.split(";")
+        .map((directive) => directive.trim())
+        .find((directive) => directive.startsWith("frame-ancestors "));
+      assert.equal(ancestors, undefined);
+      // Neither response header should restrict the embedding parent.
+      assert.equal(response.headers.get("x-frame-options"), null);
+      assert.match(policy, /script-src 'self' 'wasm-unsafe-eval';/);
+      assert.match(policy, /connect-src 'self';/);
+      assert.equal(response.headers.get("cross-origin-embedder-policy"), "require-corp");
+      assert.equal(response.headers.get("cross-origin-opener-policy"), "same-origin");
+      assert.equal(response.headers.get("cross-origin-resource-policy"), "same-origin");
+      assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+      assert.equal(response.headers.get("permissions-policy"), "camera=(), geolocation=(), serial=()");
+      await response.arrayBuffer();
+    }
+  }
+});


### PR DESCRIPTION
当前 `?play=100` 可以直接导入社区玩法，但将模拟器放进 iframe 时，浏览器会被服务端的 `frame-ancestors 'none'` 和 `X-Frame-Options: DENY` 拦截。

此 PR 移除这两项嵌入限制，允许任意来源的页面通过 iframe 打开模拟器，不设置域名白名单。其余 CSP 指令、跨源隔离和权限响应头保持原样。附带 GET/HEAD 响应头回归测试和最小 iframe 接入示例。

验证：

- `npm test`：52 项通过。
- `npm run build`、`npm run verify:release`：通过。
- Chrome 浏览器验证：将本地构建产物通过 Playwright 路由映射到模拟器的 HTTPS 地址，原样保留响应头，没有禁用 CSP；来自正式社区域名、localhost 和无关域名的父页面均可打开 iframe。
- 在正式社区来源的测试页面中，`?play=100` 成功导入「一念，云开」，运行时显示「已运行」。

远程 iframe 的修复会在模拟器部署本次更改后生效。
